### PR TITLE
Add transaction analytics endpoint

### DIFF
--- a/data/transactions.js
+++ b/data/transactions.js
@@ -1,0 +1,15 @@
+const transactions = [];
+
+function addTransaction(txn) {
+  transactions.push(txn);
+}
+
+function getTransactions() {
+  return transactions;
+}
+
+function clearTransactions() {
+  transactions.length = 0;
+}
+
+module.exports = { addTransaction, getTransactions, clearTransactions };

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "fintech-backend",
   "version": "1.0.0",
   "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "@google/generative-ai": "^0.1.3",
     "@supabase/supabase-js": "^2.39.0",

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { once } = require('node:events');
+const app = require('../index.js');
+const { clearTransactions } = require('../data/transactions.js');
+
+let server;
+
+test.beforeEach(async () => {
+  clearTransactions();
+  server = app.listen(0);
+  await once(server, 'listening');
+});
+
+test.afterEach(async () => {
+  server.close();
+  await once(server, 'close');
+});
+
+test('analytics aggregates totals', async () => {
+  const port = server.address().port;
+  const base = `http://localhost:${port}`;
+  const headers = { 'Content-Type': 'application/json' };
+
+  await fetch(`${base}/api/transactions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ Currency: 'USD', Value: 100 })
+  });
+  await fetch(`${base}/api/transactions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ Currency: 'USD', Value: 50 })
+  });
+  await fetch(`${base}/api/transactions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ Currency: 'EUR', Value: 70 })
+  });
+
+  const res = await fetch(`${base}/api/transaction-analytics`);
+  const data = await res.json();
+
+  assert.strictEqual(data.count, 3);
+  assert.strictEqual(data.totals.USD, 150);
+  assert.strictEqual(data.totals.EUR, 70);
+});


### PR DESCRIPTION
## Summary
- add simple transaction data store
- implement POST /api/transactions and GET /api/transaction-analytics
- only start server when run directly
- add analytics test using Node test runner
- expose `npm test` script

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686869c0c504832cb906759e74e8c9eb