### PR TITLE
Add dashboard and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Fintech Backend
+
+This project contains an Express backend along with a simple dashboard available as a static HTML file and as a React application.
+
+## Running Locally
+
+1. Install dependencies for the backend:
+
+```bash
+npm install
+```
+
+2. (Optional) Install dependencies for the React dashboard if you want to run it locally:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The backend runs with `node index.js` and exposes API endpoints on port `3001` by default. The React dashboard will be available at `http://localhost:5173` when running `npm run dev` from the `frontend` directory.
+
+## Deployment
+
+The project is configured for deployment on Vercel. `vercel.json` defines two builds:
+
+- The Express API (`index.js`).
+- The React dashboard located in `frontend/` and built with Vite.
+
+Static requests to `/dashboard` serve `public/dashboard.html`. The React build is served from `/dashboard-react`.
+
+To deploy, run:
+
+```bash
+vercel --prod
+```
+
+Ensure the required environment variables (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `GEMINI_API_KEY`) are set in your Vercel project settings.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>React Dashboard</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "dashboard-react",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.3.9"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,46 @@
+.container {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  line-height: 1.6;
+}
+
+.timeline {
+  list-style: none;
+  padding-left: 0;
+}
+.timeline li {
+  margin-bottom: 10px;
+}
+
+.personas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+.card {
+  border: 1px solid #ccc;
+  padding: 15px;
+  border-radius: 8px;
+  width: 200px;
+}
+
+table.raci {
+  border-collapse: collapse;
+  width: 100%;
+}
+table.raci th,
+table.raci td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+table.raci th {
+  background: #f4f4f4;
+}
+
+.diagram {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import './App.css';
+
+export default function App() {
+  return (
+    <div className="container">
+      <h1>Fintech Project Dashboard</h1>
+      <section>
+        <h2>Timeline</h2>
+        <ul className="timeline">
+          <li><strong>Phase 1:</strong> Requirements & Planning</li>
+          <li><strong>Phase 2:</strong> Prototype Development</li>
+          <li><strong>Phase 3:</strong> Testing & Feedback</li>
+          <li><strong>Phase 4:</strong> Deployment</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Personas</h2>
+        <div className="personas">
+          <div className="card">
+            <h3>Alice – Product Owner</h3>
+            <p>Defines the product vision and priorities.</p>
+          </div>
+          <div className="card">
+            <h3>Bob – Developer</h3>
+            <p>Implements features and fixes bugs.</p>
+          </div>
+          <div className="card">
+            <h3>Carol – QA Specialist</h3>
+            <p>Ensures quality through testing.</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Architecture Diagram</h2>
+        <p>The architecture is illustrated below.</p>
+        <img className="diagram" src="architecture.png" alt="Architecture Diagram placeholder" />
+      </section>
+
+      <section>
+        <h2>RACI Matrix</h2>
+        <table className="raci">
+          <thead>
+            <tr>
+              <th>Task</th>
+              <th>Responsible</th>
+              <th>Accountable</th>
+              <th>Consulted</th>
+              <th>Informed</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Requirement Gathering</td>
+              <td>Alice</td>
+              <td>Product Committee</td>
+              <td>Stakeholders</td>
+              <td>Team</td>
+            </tr>
+            <tr>
+              <td>Development</td>
+              <td>Bob</td>
+              <td>Alice</td>
+              <td>Carol</td>
+              <td>Team</td>
+            </tr>
+            <tr>
+              <td>Quality Assurance</td>
+              <td>Carol</td>
+              <td>Alice</td>
+              <td>Bob</td>
+              <td>Team</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; }
+    h1 { text-align: center; }
+    .section { margin-bottom: 40px; }
+    .personas { display: flex; flex-wrap: wrap; gap: 20px; }
+    .card { border: 1px solid #ccc; padding: 15px; border-radius: 8px; width: 200px; }
+    .timeline { list-style: none; padding-left: 0; }
+    .timeline li { margin-bottom: 10px; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+    th { background: #f4f4f4; }
+    img.diagram { max-width: 100%; height: auto; display: block; margin: 0 auto; }
+  </style>
+</head>
+<body>
+  <h1>Fintech Project Dashboard</h1>
+
+  <div class="section" id="timeline">
+    <h2>Timeline</h2>
+    <ul class="timeline">
+      <li><strong>Phase 1:</strong> Requirements &amp; Planning</li>
+      <li><strong>Phase 2:</strong> Prototype Development</li>
+      <li><strong>Phase 3:</strong> Testing &amp; Feedback</li>
+      <li><strong>Phase 4:</strong> Deployment</li>
+    </ul>
+  </div>
+
+  <div class="section" id="personas">
+    <h2>Personas</h2>
+    <div class="personas">
+      <div class="card">
+        <h3>Alice – Product Owner</h3>
+        <p>Defines the product vision and priorities.</p>
+      </div>
+      <div class="card">
+        <h3>Bob – Developer</h3>
+        <p>Implements features and fixes bugs.</p>
+      </div>
+      <div class="card">
+        <h3>Carol – QA Specialist</h3>
+        <p>Ensures quality through testing.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="section" id="architecture">
+    <h2>Architecture Diagram</h2>
+    <p>The architecture is illustrated below.</p>
+    <img class="diagram" src="architecture.png" alt="Architecture Diagram placeholder" />
+  </div>
+
+  <div class="section" id="raci">
+    <h2>RACI Matrix</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Task</th>
+          <th>Responsible</th>
+          <th>Accountable</th>
+          <th>Consulted</th>
+          <th>Informed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Requirement Gathering</td>
+          <td>Alice</td>
+          <td>Product Committee</td>
+          <td>Stakeholders</td>
+          <td>Team</td>
+        </tr>
+        <tr>
+          <td>Development</td>
+          <td>Bob</td>
+          <td>Alice</td>
+          <td>Carol</td>
+          <td>Team</td>
+        </tr>
+        <tr>
+          <td>Quality Assurance</td>
+          <td>Carol</td>
+          <td>Alice</td>
+          <td>Bob</td>
+          <td>Team</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,12 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.js", "use": "@vercel/node" }
+    { "src": "index.js", "use": "@vercel/node" },
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "frontend/dist" } }
   ],
   "routes": [
+    { "src": "/dashboard-react(/.*)?", "dest": "frontend/dist/index.html" },
+    { "src": "/dashboard", "dest": "public/dashboard.html" },
     { "src": "/(.*)", "dest": "index.js" }
   ]
 }


### PR DESCRIPTION
## Summary
- add `public/dashboard.html` with timeline, personas, architecture image, and RACI matrix
- create `frontend/` React version of the dashboard using Vite
- configure Vercel to build the React app and route `/dashboard` and `/dashboard-react`
- document running and deployment steps in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68698eb39cf8832cb3401010fa3678b7