### PR TITLE
Add dashboard and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# FinTech Backend & Dashboard
+
+This repository contains an Express API along with a dashboard available as a static HTML file and a React application.
+
+## Running Locally
+
+1. Install dependencies for the backend:
+   ```bash
+   npm install
+   ```
+2. Start the API server:
+   ```bash
+   node index.js
+   ```
+   The server listens on the port specified by the `PORT` environment variable (defaults to `3000`).
+
+### Dashboard
+
+The dashboard is available as a static file at `public/dashboard.html`.
+Open the file directly in a browser or visit `/dashboard` when deployed.
+
+## React Frontend
+
+A React version of the dashboard is located in the `frontend/` directory and uses Vite for building.
+
+### Development
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### Production Build
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+The build output will be generated in `frontend/dist/`.
+
+## Deployment
+
+[Vercel](https://vercel.com/) can be used to deploy both the API and the React dashboard.
+The `vercel.json` file configures:
+
+- Node API build from `index.js`.
+- Static build of the React app from `frontend/`.
+- Route `/dashboard` pointing to `public/dashboard.html`.
+
+After installing the [Vercel CLI](https://vercel.com/docs/cli), deploy with:
+
+```bash
+vercel --prod
+```
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dashboard React</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "dashboard-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,12 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 20px; line-height: 1.6; }
+header { text-align: center; margin-bottom: 40px; }
+.timeline { list-style: none; padding: 0; }
+.timeline li { margin-bottom: 20px; position: relative; padding-left: 20px; }
+.timeline li::before { content: ''; position: absolute; left: 0; top: 5px; width: 10px; height: 10px; background: #333; border-radius: 50%; }
+.personas { display: flex; gap: 20px; flex-wrap: wrap; }
+.persona { border: 1px solid #ccc; border-radius: 4px; padding: 10px; width: 200px; text-align: center; }
+.persona img { width: 100%; height: 150px; object-fit: cover; border-radius: 4px; }
+.diagram { text-align: center; margin: 40px 0; }
+.raci { border-collapse: collapse; width: 100%; }
+.raci th, .raci td { border: 1px solid #ccc; padding: 8px; text-align: center; }
+.raci th { background-color: #f0f0f0; }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import './App.css';
+
+function Timeline() {
+  const events = [
+    { month: 'Jan', text: 'Project kickoff' },
+    { month: 'Feb', text: 'Requirements gathering' },
+    { month: 'Mar', text: 'Prototype development' },
+    { month: 'Apr', text: 'User testing' },
+    { month: 'May', text: 'Launch' }
+  ];
+  return (
+    <ul className="timeline">
+      {events.map(e => (
+        <li key={e.month}><strong>{e.month}:</strong> {e.text}</li>
+      ))}
+    </ul>
+  );
+}
+
+function Personas() {
+  const people = [
+    { name: 'Analyst Alice', desc: 'Focuses on data-driven insights.' },
+    { name: 'Developer Dan', desc: 'Implements product features.' },
+    { name: 'Manager Maria', desc: 'Oversees deliverables and timelines.' }
+  ];
+  return (
+    <div className="personas">
+      {people.map(p => (
+        <div className="persona" key={p.name}>
+          <img src="https://via.placeholder.com/200x150" alt={p.name} />
+          <h3>{p.name}</h3>
+          <p>{p.desc}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <div className="app">
+      <header><h1>Project Dashboard</h1></header>
+      <section>
+        <h2>Timeline</h2>
+        <Timeline />
+      </section>
+      <section>
+        <h2>Personas</h2>
+        <Personas />
+      </section>
+      <section className="diagram">
+        <h2>Architecture Diagram</h2>
+        <img src="https://via.placeholder.com/600x300" alt="Architecture" />
+      </section>
+      <section>
+        <h2>RACI Matrix</h2>
+        <table className="raci">
+          <thead>
+            <tr><th>Task</th><th>Analyst</th><th>Developer</th><th>Manager</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Requirements</td><td>R</td><td>C</td><td>A</td></tr>
+            <tr><td>Implementation</td><td>C</td><td>R</td><td>A</td></tr>
+            <tr><td>Testing</td><td>C</td><td>R</td><td>A</td></tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 20px; line-height: 1.6; }
+        header { text-align: center; margin-bottom: 40px; }
+        h1 { margin: 0; }
+        .timeline { list-style: none; padding: 0; }
+        .timeline li { margin-bottom: 20px; position: relative; padding-left: 20px; }
+        .timeline li::before { content: ""; position: absolute; left: 0; top: 5px; width: 10px; height: 10px; background: #333; border-radius: 50%; }
+        .personas { display: flex; gap: 20px; flex-wrap: wrap; }
+        .persona { border: 1px solid #ccc; border-radius: 4px; padding: 10px; width: 200px; text-align: center; }
+        .persona img { width: 100%; height: 150px; object-fit: cover; border-radius: 4px; }
+        .diagram { text-align: center; margin: 40px 0; }
+        .raci { border-collapse: collapse; width: 100%; }
+        .raci th, .raci td { border: 1px solid #ccc; padding: 8px; text-align: center; }
+        .raci th { background-color: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Project Dashboard</h1>
+    </header>
+
+    <section>
+        <h2>Timeline</h2>
+        <ul class="timeline">
+            <li><strong>Jan:</strong> Project kickoff</li>
+            <li><strong>Feb:</strong> Requirements gathering</li>
+            <li><strong>Mar:</strong> Prototype development</li>
+            <li><strong>Apr:</strong> User testing</li>
+            <li><strong>May:</strong> Launch</li>
+        </ul>
+    </section>
+
+    <section>
+        <h2>Personas</h2>
+        <div class="personas">
+            <div class="persona">
+                <img src="https://via.placeholder.com/200x150" alt="Analyst" />
+                <h3>Analyst Alice</h3>
+                <p>Focuses on data-driven insights.</p>
+            </div>
+            <div class="persona">
+                <img src="https://via.placeholder.com/200x150" alt="Developer" />
+                <h3>Developer Dan</h3>
+                <p>Implements product features.</p>
+            </div>
+            <div class="persona">
+                <img src="https://via.placeholder.com/200x150" alt="Manager" />
+                <h3>Manager Maria</h3>
+                <p>Oversees deliverables and timelines.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="diagram">
+        <h2>Architecture Diagram</h2>
+        <img src="https://via.placeholder.com/600x300" alt="Architecture Diagram" />
+    </section>
+
+    <section>
+        <h2>RACI Matrix</h2>
+        <table class="raci">
+            <tr>
+                <th>Task</th>
+                <th>Analyst</th>
+                <th>Developer</th>
+                <th>Manager</th>
+            </tr>
+            <tr>
+                <td>Requirements</td>
+                <td>R</td>
+                <td>C</td>
+                <td>A</td>
+            </tr>
+            <tr>
+                <td>Implementation</td>
+                <td>C</td>
+                <td>R</td>
+                <td>A</td>
+            </tr>
+            <tr>
+                <td>Testing</td>
+                <td>C</td>
+                <td>R</td>
+                <td>A</td>
+            </tr>
+        </table>
+    </section>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,12 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.js", "use": "@vercel/node" }
+    { "src": "index.js", "use": "@vercel/node" },
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "frontend/dist" } }
   ],
   "routes": [
+    { "src": "/dashboard", "dest": "public/dashboard.html" },
+    { "src": "/static/(.*)", "dest": "public/$1" },
     { "src": "/(.*)", "dest": "index.js" }
   ]
 }


### PR DESCRIPTION
## Summary
- add a project dashboard static HTML page
- include a React version of the dashboard under `frontend/`
- route `/dashboard` to the static file and configure static build for React
- document running and deployment instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68698eb747fc832c8c568bb8ac3a32af