### PR TITLE
Add project tracker endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Fintech Backend
+
+## Project Tracker
+
+The tracker endpoint `/api/tracker` serves the tasks defined in `project_tasks.json`.
+Open `public/tracker.html` in a browser to see the list.
+
+### Updating tasks
+1. Edit `project_tasks.json` in the repository root.
+2. Add or update task objects with fields:
+   - `id`: unique number
+   - `title`: short description
+   - `status`: e.g. `pending`, `in progress`, `complete`
+   - `progress`: 0-100
+3. Restart the server so the changes are picked up.

--- a/index.js
+++ b/index.js
@@ -3,10 +3,13 @@ const express = require('express');
 const { createClient } = require('@supabase/supabase-js');
 const { GoogleGenerativeAI } = require('@google/generative-ai');
 const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 app.use(express.json());
 app.use(cors());
+app.use(express.static('public'));
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
@@ -44,6 +47,17 @@ app.post('/api/query-supabase', async (req, res) => {
     } catch (error) {
         console.error('Server Error:', error);
         res.status(500).json({ error: 'An internal server error occurred.' });
+    }
+});
+
+app.get('/api/tracker', (req, res) => {
+    try {
+        const data = fs.readFileSync(path.join(__dirname, 'project_tasks.json'), 'utf8');
+        const tasks = JSON.parse(data);
+        res.json({ tasks });
+    } catch (err) {
+        console.error('Tracker Error:', err);
+        res.status(500).json({ error: 'Failed to load tasks' });
     }
 });
 

--- a/project_tasks.json
+++ b/project_tasks.json
@@ -1,0 +1,6 @@
+[
+  {"id":1,"title":"Kickoff Cosmic Nexus","status":"complete","progress":100},
+  {"id":2,"title":"Establish API services","status":"in progress","progress":60},
+  {"id":3,"title":"Create user portal","status":"pending","progress":0},
+  {"id":4,"title":"Launch and monitor","status":"pending","progress":0}
+]

--- a/public/tracker.html
+++ b/public/tracker.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Project Tracker</title>
+</head>
+<body>
+<h1>Cosmic Nexus Tasks</h1>
+<ul id="task-list"></ul>
+<script>
+fetch('/api/tracker')
+  .then(r => r.json())
+  .then(data => {
+    const list = document.getElementById('task-list');
+    data.tasks.forEach(t => {
+      const li = document.createElement('li');
+      li.textContent = `${t.title} - ${t.status} (${t.progress}%)`;
+      list.appendChild(li);
+    });
+  })
+  .catch(err => {
+    document.getElementById('task-list').textContent = 'Failed to load tasks';
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve `public` folder and add `/api/tracker` endpoint
- list project tasks in `project_tasks.json`
- simple tracker UI in `public/tracker.html`
- document updating the tracker in `README`
- ignore lockfile and node_modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869e21e80d0832ca225fcb25f8381cd