### PR TITLE
Add mobile web interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const cors = require('cors');
 const app = express();
 app.use(express.json());
 app.use(cors());
+// Serve static files from the public directory
+app.use(express.static('public'));
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,79 @@
-// ...después de const answer = …
-if (process.env.SLACK_WEBHOOK_URL) {
-  await fetch(process.env.SLACK_WEBHOOK_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      channel: '#lean2-dev',               // fuerza canal destino
-      text: `🤖 Cosmo responde: ${answer}`
-    })
-  });
-}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <link rel="manifest" href="manifest.json" />
+  <title>Cosmo Mobile</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: #f7f7f7;
+      font-family: system-ui, sans-serif;
+    }
+    #app {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      padding: 1rem;
+      background: #111;
+      color: #fff;
+      text-align: center;
+    }
+    main {
+      flex: 1;
+      padding: 1rem;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    textarea {
+      width: 100%;
+      height: 6rem;
+    }
+    button {
+      padding: 0.5rem 1rem;
+      background: #111;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+    }
+    pre {
+      background: #eee;
+      padding: 0.5rem;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <header>Cosmo</header>
+    <main>
+      <textarea id="prompt" placeholder="Enter your query"></textarea>
+      <button id="submit">Submit</button>
+      <pre id="output"></pre>
+    </main>
+  </div>
+  <script>
+    document.getElementById('submit').addEventListener('click', async () => {
+      const prompt = document.getElementById('prompt').value.trim();
+      if (!prompt) return;
+      const res = await fetch('/api/query-supabase', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, tableName: 'transactions' })
+      });
+      const data = await res.json();
+      document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Cosmo Mobile",
+  "short_name": "Cosmo",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f7f7f7",
+  "theme_color": "#111111",
+  "icons": []
+}


### PR DESCRIPTION
## Summary
- serve static files from `public`
- add a minimal mobile-optimized interface in `public/index.html`
- include `manifest.json` for PWA-like full-screen behavior

## Testing
- `npm install --silent`
- `node index.js` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_686a12824284832c895d83fdc7abef30