### PR TITLE
Add smart contracts and cycle API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+contracts/artifacts/
+contracts/cache/
+package-lock.json

--- a/contracts/contracts/CheckpointNFT.sol
+++ b/contracts/contracts/CheckpointNFT.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/Base64.sol";
+
+/// @title CheckpointNFT - ERC721 token with dynamic metadata
+contract CheckpointNFT is ERC721URIStorage, Ownable {
+    struct Meta {
+        uint256 cycleId;
+        string status;
+    }
+
+    mapping(uint256 => Meta) private _metadata;
+    uint256 private _tokenIdCounter;
+
+    constructor(address initialOwner) ERC721("CheckpointNFT", "CKPT") Ownable(initialOwner) {}
+
+    /// @notice Mint a new NFT representing a cycle checkpoint
+    /// @param to recipient address
+    /// @param cycleId cycle identifier
+    /// @param status description stored in metadata
+    function mint(address to, uint256 cycleId, string memory status) external onlyOwner returns (uint256) {
+        uint256 tokenId = ++_tokenIdCounter;
+        _safeMint(to, tokenId);
+        _metadata[tokenId] = Meta(cycleId, status);
+        return tokenId;
+    }
+
+    /// @dev Generates token URI on the fly using Base64 encoded JSON
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        require(_ownerOf(tokenId) != address(0), "ERC721: invalid token");
+        Meta memory m = _metadata[tokenId];
+        string memory json = string(abi.encodePacked(
+            '{"name":"Checkpoint ', Strings.toString(tokenId), '",',
+            '"description":"Cycle ', Strings.toString(m.cycleId), ' status: ', m.status, '",' ,
+            '"attributes":[{"trait_type":"cycleId","value":', Strings.toString(m.cycleId), '}]}'
+        ));
+        return string(abi.encodePacked('data:application/json;base64,', Base64.encode(bytes(json))));
+    }
+}

--- a/contracts/contracts/CreditToken.sol
+++ b/contracts/contracts/CreditToken.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title CreditToken - simple ERC20 used as credit tokens
+contract CreditToken is ERC20, Ownable {
+    constructor(address initialOwner) ERC20("CreditToken", "CRD") Ownable(initialOwner) {}
+
+    /// @notice Mint tokens to an address
+    /// @param to recipient address
+    /// @param amount token amount (in wei)
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+}

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -1,0 +1,11 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test",
+    cache: "./cache",
+    artifacts: "./artifacts"
+  }
+};

--- a/contracts/test/token.js
+++ b/contracts/test/token.js
@@ -1,0 +1,24 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CreditToken", function () {
+  it("mints tokens", async function () {
+    const [owner, addr] = await ethers.getSigners();
+    const Credit = await ethers.getContractFactory("CreditToken");
+    const credit = await Credit.deploy(owner.address);
+    await credit.mint(addr.address, 100);
+    expect(await credit.balanceOf(addr.address)).to.equal(100);
+  });
+});
+
+describe("CheckpointNFT", function () {
+  it("mints nft and returns metadata", async function () {
+    const [owner, addr] = await ethers.getSigners();
+    const NFT = await ethers.getContractFactory("CheckpointNFT");
+    const nft = await NFT.deploy(owner.address);
+    await nft.mint(addr.address, 1, "open");
+    const uri = await nft.tokenURI(1);
+    expect(uri).to.contain("data:application/json;base64,");
+    expect(await nft.ownerOf(1)).to.equal(addr.address);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const { createClient } = require('@supabase/supabase-js');
 const { GoogleGenerativeAI } = require('@google/generative-ai');
+const { ethers } = require('ethers');
 const cors = require('cors');
 
 const app = express();
@@ -11,6 +12,10 @@ app.use(cors());
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const ETH_PROVIDER_URL = process.env.ETH_PROVIDER_URL;
+const WALLET_PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY;
+const CREDIT_TOKEN_ADDRESS = process.env.CREDIT_TOKEN_ADDRESS;
+const CHECKPOINT_NFT_ADDRESS = process.env.CHECKPOINT_NFT_ADDRESS;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !GEMINI_API_KEY) {
     console.error("CRITICAL ERROR: Missing environment variables.");
@@ -19,6 +24,19 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !GEMINI_API_KEY) {
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
 const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash"});
+
+let creditToken;
+let checkpointNFT;
+if (ETH_PROVIDER_URL && WALLET_PRIVATE_KEY && CREDIT_TOKEN_ADDRESS && CHECKPOINT_NFT_ADDRESS) {
+    const provider = new ethers.JsonRpcProvider(ETH_PROVIDER_URL);
+    const wallet = new ethers.Wallet(WALLET_PRIVATE_KEY, provider);
+    const creditAbi = require('./contracts/artifacts/contracts/CreditToken.sol/CreditToken.json').abi;
+    const nftAbi = require('./contracts/artifacts/contracts/CheckpointNFT.sol/CheckpointNFT.json').abi;
+    creditToken = new ethers.Contract(CREDIT_TOKEN_ADDRESS, creditAbi, wallet);
+    checkpointNFT = new ethers.Contract(CHECKPOINT_NFT_ADDRESS, nftAbi, wallet);
+} else {
+    console.warn('Token contracts not configured. Minting endpoints disabled.');
+}
 
 app.post('/api/query-supabase', async (req, res) => {
     const { prompt, tableName } = req.body;
@@ -45,6 +63,69 @@ app.post('/api/query-supabase', async (req, res) => {
         console.error('Server Error:', error);
         res.status(500).json({ error: 'An internal server error occurred.' });
     }
+});
+
+// helper to fetch oracle price (BTC/USD for demo)
+async function getOraclePrice() {
+    try {
+        const resp = await fetch('https://api.coindesk.com/v1/bpi/currentprice/USD.json');
+        const data = await resp.json();
+        return parseFloat(data.bpi.USD.rate.replace(',', ''));
+    } catch (err) {
+        console.error('Oracle fetch failed:', err);
+        return null;
+    }
+}
+
+app.get('/api/oracle-price', async (req, res) => {
+    const price = await getOraclePrice();
+    if (!price) return res.status(500).json({ error: 'oracle unavailable' });
+    res.json({ price });
+});
+
+app.post('/api/start-cycle', async (req, res) => {
+    const start = new Date();
+    const end = new Date(start.getTime() + 28 * 24 * 60 * 60 * 1000);
+    const price = await getOraclePrice();
+    const { data, error } = await supabase
+        .from('cycles')
+        .insert({ start_date: start.toISOString(), end_date: end.toISOString(), cycle_status: 'active', oracle_price: price })
+        .select()
+        .single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(data);
+});
+
+app.post('/api/mint-credit', async (req, res) => {
+    if (!creditToken) return res.status(500).json({ error: 'contract not configured' });
+    const { to, amount } = req.body;
+    try {
+        const tx = await creditToken.mint(to, amount);
+        await tx.wait();
+        res.json({ hash: tx.hash });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+app.post('/api/mint-nft', async (req, res) => {
+    if (!checkpointNFT) return res.status(500).json({ error: 'contract not configured' });
+    const { to, cycleId, status } = req.body;
+    try {
+        const tx = await checkpointNFT.mint(to, cycleId, status);
+        const receipt = await tx.wait();
+        const tokenId = receipt.events.find(e => e.event === 'Transfer').args.tokenId.toString();
+        await supabase.from('cycles').update({ checkpoint_nft_id: tokenId }).eq('id', cycleId);
+        res.json({ tokenId });
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});
+
+app.get('/api/cycle/:id', async (req, res) => {
+    const { data, error } = await supabase.from('cycles').select('*').eq('id', req.params.id).single();
+    if (error) return res.status(500).json({ error: error.message });
+    res.json(data);
 });
 
 const PORT = process.env.PORT || 3001;

--- a/package.json
+++ b/package.json
@@ -2,10 +2,25 @@
   "name": "fintech-backend",
   "version": "1.0.0",
   "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "jest",
+    "test:contracts": "cd contracts && npx hardhat test"
+  },
   "dependencies": {
     "@google/generative-ai": "^0.1.3",
     "@supabase/supabase-js": "^2.39.0",
     "cors": "^2.8.5",
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "hardhat": "^2.20.0",
+    "@openzeppelin/contracts": "^5.0.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+const app = require('../index');
+
+jest.mock('@supabase/supabase-js', () => {
+  return {
+    createClient: () => ({
+      from: () => ({
+        insert: () => ({ select: () => ({ single: () => ({ data: { id: 1, cycle_status: 'active' }, error: null }) }) }),
+        update: () => ({ eq: () => ({}) }),
+        select: () => ({ eq: () => ({ single: () => ({ data: {}, error: null }) }) })
+      })
+    })
+  };
+});
+
+describe('API routes', () => {
+  it('starts a cycle', async () => {
+    const res = await request(app).post('/api/start-cycle');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.cycle_status).toBe('active');
+  });
+});


### PR DESCRIPTION
## Summary
- add ERC20 `CreditToken` and ERC721 `CheckpointNFT` solidity contracts
- configure Hardhat project with tests
- extend Express API for minting, cycle tracking, and oracle pricing
- store cycle data in Supabase
- add Jest and Hardhat tests

## Testing
- `npm test --silent`
- `npm run test:contracts --silent`


------
https://chatgpt.com/codex/tasks/task_e_686a10fe2d20832c8f43cc80f2525093