### PR TITLE
Rewrite public page and centralize Slack hook

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { sendSlackMessage } from "../slack.js";
 
 // Mini Xibalbá storage endpoint
 import { put, list, get } from '@vercel/blob';
@@ -56,16 +57,11 @@ export default async function handler(req, res) {
     const answer = msgList.data[0].content[0].text.value;
 
     // 3. Relay to Slack
-    if (SLACK_WEBHOOK) {
-      await fetch(SLACK_WEBHOOK, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          channel: process.env.SLACK_CHANNEL || '#cosmic-nexus-it',
-          text: `🤖 Cosmo responde: ${answer}`
-        })
-      });
-    }
+    await sendSlackMessage(
+      SLACK_WEBHOOK,
+      `🤖 Cosmo responde: ${answer}`,
+      process.env.SLACK_CHANNEL
+    );
 
     // 4. Return to user
     res.status(200).json({ answer });

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,13 @@
-// ...después de const answer = …
-if (process.env.SLACK_WEBHOOK_URL) {
-  await fetch(process.env.SLACK_WEBHOOK_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      channel: '#lean2-dev',               // fuerza canal destino
-      text: `🤖 Cosmo responde: ${answer}`
-    })
-  });
-}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Fintech Backend API</title>
+</head>
+<body>
+  <h1>Fintech Backend API</h1>
+  <p>Welcome! This backend exposes endpoints for Supabase queries and the Cosmo chatbot.</p>
+  <p>Send POST requests to <code>/api/query-supabase</code> to generate SQL from natural language.
+  Use <code>/api/chat</code> for Cosmo AI assistance.</p>
+</body>
+</html>

--- a/slack.js
+++ b/slack.js
@@ -1,0 +1,8 @@
+export async function sendSlackMessage(webhookUrl, text, channel = process.env.SLACK_CHANNEL || '#cosmic-nexus-it') {
+  if (!webhookUrl) return;
+  await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ channel, text })
+  });
+}


### PR DESCRIPTION
## Summary
- replace `public/index.html` with a short introduction to the API
- create `slack.js` helper for posting to Slack
- use the helper in `api/chat.js`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a10faddcc832c8ecbd5bc0a83f74c