### PR TITLE
Create HTML landing page and move Slack logic

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -2,10 +2,10 @@ import OpenAI from "openai";
 
 // Mini Xibalbá storage endpoint
 import { put, list, get } from '@vercel/blob';
+import sendSlackMessage from '../lib/slack-notifier.js';
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const ASSISTANT_ID = process.env.ASSISTANT_ID;  // e.g. asst_xxx
-const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK_URL;
 
 export default async function handler(req, res) {
   try {
@@ -56,16 +56,7 @@ export default async function handler(req, res) {
     const answer = msgList.data[0].content[0].text.value;
 
     // 3. Relay to Slack
-    if (SLACK_WEBHOOK) {
-      await fetch(SLACK_WEBHOOK, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          channel: process.env.SLACK_CHANNEL || '#cosmic-nexus-it',
-          text: `🤖 Cosmo responde: ${answer}`
-        })
-      });
-    }
+    await sendSlackMessage(`🤖 Cosmo responde: ${answer}`);
 
     // 4. Return to user
     res.status(200).json({ answer });

--- a/lib/slack-notifier.js
+++ b/lib/slack-notifier.js
@@ -1,0 +1,12 @@
+export default async function sendSlackMessage(text) {
+  const webhook = process.env.SLACK_WEBHOOK_URL;
+  const channel = process.env.SLACK_CHANNEL || '#cosmic-nexus-it';
+
+  if (!webhook) return;
+
+  await fetch(webhook, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ channel, text })
+  });
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,22 @@
-// ...después de const answer = …
-if (process.env.SLACK_WEBHOOK_URL) {
-  await fetch(process.env.SLACK_WEBHOOK_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      channel: '#lean2-dev',               // fuerza canal destino
-      text: `🤖 Cosmo responde: ${answer}`
-    })
-  });
-}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fintech Backend API</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        code { background: #f4f4f4; padding: 2px 4px; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <h1>Fintech Backend API</h1>
+    <p>This service exposes several endpoints for interacting with financial data and the Cosmo assistant.</p>
+    <ul>
+        <li><code>POST /api/query-supabase</code> – generate SQL with AI and query your Supabase database.</li>
+        <li><code>POST /api/chat</code> – ask questions to the Cosmo Triage assistant.</li>
+        <li><code>GET/POST /api/xibalba-mini</code> – store and retrieve JSON messages.</li>
+    </ul>
+    <p>See the project documentation for setup instructions and more details.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `public/index.html` with a simple description of available API endpoints
- encapsulate Slack notification logic in `lib/slack-notifier.js`
- use the new notifier from `api/chat.js`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a129f8c38832ca45ae4f80d238d56