### PR TITLE
Exit server if env vars missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !GEMINI_API_KEY) {
     console.error("CRITICAL ERROR: Missing environment variables.");
+    // Terminate early so the server doesn't start with an invalid configuration
+    process.exit(1);
 }
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- stop `index.js` if essential environment variables are absent
- add comment explaining why

## Testing
- `npx hardhat compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687af6312ae4832c99d4c56fe5e859b0