### PR TITLE
Require PRIVATE_KEY env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The server requires several variables. Create a `.env` file or configure them in
 - `SUPABASE_ANON_KEY` – Supabase anonymous key
 - `GEMINI_API_KEY` – Google Gemini API key
 - `RPC_URL` – Ethereum RPC endpoint (default `http://127.0.0.1:8545`)
-- `PRIVATE_KEY` – Private key used to sign transactions
+- `PRIVATE_KEY` – **required** private key used to sign transactions. The server will exit on startup if this value is missing.
 - `CREDIT_TOKEN_ADDRESS` – Deployed `CreditToken` contract address
 - `NFT_ADDRESS` – Deployed `DynamicMetadataNFT` contract address
 - `OPENAI_API_KEY` – OpenAI key for `api/chat.js`

--- a/api-tests/app.test.js
+++ b/api-tests/app.test.js
@@ -1,6 +1,7 @@
 process.env.SUPABASE_URL = 'http://localhost';
 process.env.SUPABASE_ANON_KEY = 'anon';
 process.env.GEMINI_API_KEY = 'key';
+process.env.PRIVATE_KEY = '0x0123456789012345678901234567890123456789012345678901234567890123';
 const request = require('supertest');
 const { app, supabase, credit, nft } = require('../index');
 

--- a/index.js
+++ b/index.js
@@ -14,16 +14,18 @@ app.use(cors());
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const PRIVATE_KEY = process.env.PRIVATE_KEY;
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !GEMINI_API_KEY) {
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !GEMINI_API_KEY || !PRIVATE_KEY) {
     console.error("CRITICAL ERROR: Missing environment variables.");
+    process.exit(1);
 }
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
 const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash"});
 const provider = new ethers.JsonRpcProvider(process.env.RPC_URL || "http://127.0.0.1:8545");
-const signer = new ethers.Wallet(process.env.PRIVATE_KEY || ethers.Wallet.createRandom().privateKey, provider);
+const signer = new ethers.Wallet(PRIVATE_KEY, provider);
 const credit = new ethers.Contract(process.env.CREDIT_TOKEN_ADDRESS || ethers.ZeroAddress, creditAbi, signer);
 const nft = new ethers.Contract(process.env.NFT_ADDRESS || ethers.ZeroAddress, nftAbi, signer);
 


### PR DESCRIPTION
## Summary
- exit early if PRIVATE_KEY or other env vars are missing
- use the provided key when instantiating the signer
- update README to note PRIVATE_KEY is mandatory
- set PRIVATE_KEY in tests

## Testing
- `npm test`
- `npm run test:contracts`


------
https://chatgpt.com/codex/tasks/task_e_687af6887970832c9428c56b142b7a73