### PR TITLE
Run hardhat compile before jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ The server requires several variables. Create a `.env` file or configure them in
    ```bash
    npm install
    ```
-2. Compile the Solidity contracts (required before running tests):
+2. Compile the Solidity contracts:
    ```bash
    npx hardhat compile
    ```
+   The test script automatically runs this command before executing the Jest
+   suite, so manual compilation is only necessary when deploying or interacting
+   with contracts directly.
 
 ## Running the Server
 
@@ -47,7 +50,8 @@ Open `public/index.html` in your browser to view the React Agile blueprint.
 
 ## Tests
 
-Run API and contract tests:
+Run API and contract tests. The `npm test` command will compile your
+Solidity contracts automatically before running Jest:
 
 ```bash
 npm test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "supertest": "^7.1.1"
   },
   "scripts": {
-    "test": "jest",
+    "test": "hardhat compile && jest",
     "test:contracts": "hardhat test"
   },
   "jest": {


### PR DESCRIPTION
## Summary
- make tests compile contracts before Jest
- mention automatic compilation in README

## Testing
- `npm test`
- `npm run test:contracts`


------
https://chatgpt.com/codex/tasks/task_e_687af6b119f0832cb76b9aaf4c34651f