### PR TITLE
Add blackboard addon context

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ node index.js
 
 Open `public/index.html` in your browser to view the React Agile blueprint.
 
+### Webporting Add-ons
+
+The front-end exposes a simple plug-in system powered by `public/blackboard.js`.
+Any script can register a React component globally by calling:
+
+```js
+window.Blackboard.registerAddon(MyComponent);
+```
+
+Both `CosmicNexusApp` (in `index.html`) and the `Scriptment` view read
+from this context and render all registered add-ons below the main
+content. An example add-on is provided in `public/addons/HelloAddon.js`.
+
 ## Tests
 
 Run API and contract tests:

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const nftAbi = require('./artifacts/contracts/DynamicMetadataNFT.sol/DynamicMeta
 const app = express();
 app.use(express.json());
 app.use(cors());
+app.use(express.static('public'));
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;

--- a/public/Scriptment.jsx
+++ b/public/Scriptment.jsx
@@ -1,0 +1,186 @@
+const { useState, useEffect, useContext } = React;
+
+function Scriptment(){
+  const [data, setData] = useState(null);
+  const [activeTab, setActiveTab] = useState('team');
+  const [flipped, setFlipped] = useState({});
+  const [open, setOpen] = useState({});
+  const [comm, setComm] = useState(null);
+  const addons = useContext(window.Blackboard.AddonContext || React.createContext([]));
+
+  useEffect(() => {
+    fetch('scenes.json').then(r=>r.json()).then(setData);
+  }, []);
+
+  useEffect(() => {
+    async function load(){
+      try{
+        const manifest = await fetch('addons/manifest.json').then(r=>r.json());
+        for(const file of manifest.modules){
+          await import(`./addons/${file}`);
+        }
+      }catch(err){
+        console.error('addon load', err);
+      }
+    }
+    load();
+  }, []);
+
+  useEffect(() => {
+    if(activeTab==='sprint'){
+      const ctx = document.getElementById('burndownChart');
+      if(ctx){
+        const sprintDays=10; const totalStoryPoints=10;
+        const idealData=Array.from({length:sprintDays+1},(_,i)=>totalStoryPoints-(totalStoryPoints/sprintDays)*i);
+        const actualData=[10,10,10,8,8,5,5,2,2,0,0];
+        new Chart(ctx.getContext('2d'),{
+          type:'line',
+          data:{
+            labels:Array.from({length:sprintDays+1},(_,i)=>`Day ${i}`),
+            datasets:[
+              {label:'Ideal',data:idealData,borderColor:'#9ca3af',borderDash:[5,5],backgroundColor:'transparent',pointRadius:0,tension:0.1},
+              {label:'Actual',data:actualData.slice(0,idealData.length),borderColor:'#0d9488',backgroundColor:'rgba(13,148,136,0.1)',fill:true,tension:0.1}
+            ]
+          },
+          options:{responsive:true,maintainAspectRatio:false,scales:{y:{beginAtZero:true,title:{display:true,text:'Story Points'}},x:{title:{display:true,text:'Sprint Day'}}}}
+        });
+      }
+    }
+  }, [activeTab]);
+
+  const toggleCard=name=>setFlipped(p=>({...p,[name]:!p[name]}));
+  const toggleAcc=name=>setOpen(p=>({...p,[name]:!p[name]}));
+
+  if(!data) return React.createElement('div', {className:'p-4'}, 'Loading...');
+
+  return (
+    <div className="container mx-auto p-4 md:p-8">
+      <header className="text-center mb-8 md:mb-12">
+        <h1 className="text-3xl md:text-4xl font-bold text-teal-700">Scriptment</h1>
+        <p className="mt-2 text-lg text-stone-600">Interactive blueprint powered by JSON scenes and add-ons.</p>
+      </header>
+      <nav className="mb-8 border-b border-stone-200">
+        <ul className="flex flex-wrap -mb-px text-sm font-medium text-center text-stone-500">
+          {['team','sprint','framework','practices'].map(tab=>(
+            <li key={tab} className="mr-2">
+              <button className={`nav-tab inline-block p-4 border-b-2 rounded-t-lg ${activeTab===tab?'border-teal-600 text-teal-600 font-semibold':'border-transparent text-stone-500'}`} onClick={()=>setActiveTab(tab)}>{tab}</button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <main>
+        <section id="team" className={activeTab==='team'?'':'hidden'}>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {data.team.map(member=>(
+              <div key={member.name} className={flipped[member.name] ? 'card-flipper perspective-1000 flipped' : 'card-flipper perspective-1000'} onClick={()=>toggleCard(member.name)}>
+                <div className="card-flip relative w-full h-80">
+                  <div className="card-front absolute w-full h-full p-6 bg-white rounded-xl shadow-lg border border-stone-200 flex flex-col items-center justify-center text-center">
+                    <div className="text-6xl mb-4">{member.emoji}</div>
+                    <h3 className="text-xl font-bold text-teal-700">{member.name}</h3>
+                    <p className="text-lg font-semibold text-stone-700">{member.role}</p>
+                    <p className="mt-2 text-sm text-stone-500">{member.mission}</p>
+                    <button className="mt-4 text-teal-600 font-semibold text-sm">View Details →</button>
+                  </div>
+                  <div className="card-back absolute w-full h-full p-6 bg-white rounded-xl shadow-lg border border-stone-200 flex flex-col">
+                    <h4 className="font-bold text-teal-700">Key Responsibilities</h4>
+                    <ul className="list-disc list-inside text-sm text-stone-600 mt-2 space-y-1 flex-grow">
+                      {member.responsibilities.map((r,i)=>(<li key={i}>{r}</li>))}
+                    </ul>
+                    <button className="mt-4 text-teal-600 font-semibold text-sm">← Back</button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+        <section id="sprint" className={activeTab==='sprint'?'mt-8':'hidden'}>
+          <h2 className="text-xl font-bold mb-4">{data.sprint.title}</h2>
+          <p className="text-stone-600 mb-4">{data.sprint.goal}</p>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="lg:col-span-2 space-y-4">
+              {data.sprint.stories.map((story,idx)=>(
+                <div key={idx} className="bg-white p-4 rounded-lg border border-stone-200 shadow-sm">
+                  <h4 className="font-semibold">{story.name}</h4>
+                  <p className="text-sm text-stone-600 mt-1">{story.description}</p>
+                  <div className={open['story'+idx]?'mt-4 pt-4 border-t border-stone-200':'hidden mt-4 pt-4 border-t border-stone-200'}>
+                    <h5 className="font-semibold text-sm">Acceptance Criteria</h5>
+                    <ul className="list-disc list-inside text-sm text-stone-600 mt-1 space-y-1">
+                      {story.acceptance.map((a,i)=>(<li key={i}>{a}</li>))}
+                    </ul>
+                    <h5 className="font-semibold text-sm mt-3">Decomposed Tasks</h5>
+                    <ul className="list-disc list-inside text-sm text-stone-600 mt-1 space-y-1">
+                      {story.tasks.map((t,i)=>(<li key={i}>{t}</li>))}
+                    </ul>
+                  </div>
+                  <button className="accordion-toggle text-teal-600 text-sm font-semibold mt-2" onClick={()=>toggleAcc('story'+idx)}>{open['story'+idx]?'Hide Details ▲':'Show Details ▼'}</button>
+                </div>
+              ))}
+            </div>
+            <div>
+              <h3 className="font-bold text-xl mb-4">Sprint Burndown</h3>
+              <div className="bg-white p-4 rounded-lg border border-stone-200 shadow-sm">
+                <div className="chart-container" style={{position:'relative',width:'100%',height:'300px'}}>
+                  <canvas id="burndownChart"></canvas>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section id="framework" className={activeTab==='framework'?'mt-8':'hidden'}>
+          <h2 className="text-xl font-bold mb-4">Acceptance Criteria vs Definition of Done</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+            <div className="bg-white p-6 rounded-lg border-2 border-teal-100 shadow-sm">
+              <h4 className="font-bold text-lg text-teal-700">Acceptance Criteria</h4>
+              <ul className="list-disc list-inside text-stone-700 space-y-2 text-sm">
+                {data.framework.ac.map((a,i)=>(<li key={i}>{a}</li>))}
+              </ul>
+            </div>
+            <div className="bg-white p-6 rounded-lg border-2 border-stone-300 shadow-sm">
+              <h4 className="font-bold text-lg text-stone-700">Definition of Done</h4>
+              <ul className="list-disc list-inside text-stone-700 space-y-2 text-sm">
+                {data.framework.dod.map((d,i)=>(<li key={i}>{d}</li>))}
+              </ul>
+            </div>
+          </div>
+          <div className="mt-8">
+            <h3 className="text-xl font-bold text-center mb-6">Communication Protocol</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 text-center">
+              {Object.keys(data.framework.comm).map(name => (
+                <div key={name} className={`comm-item bg-white p-4 rounded-lg shadow-sm border cursor-pointer hover:shadow-md ${comm===name ? 'border-teal-400 bg-teal-50' : 'border-stone-200'}`} onClick={()=>setComm(name)}>
+                  <h4 className="font-semibold text-sm">{name}</h4>
+                </div>
+              ))}
+            </div>
+            <div id="comm-details" className="mt-6 bg-teal-50/50 p-6 rounded-lg border border-teal-100 min-h-[160px]">
+              {comm ? (
+                <div className="text-left">
+                  <h4 className="font-bold text-teal-700">{comm}</h4>
+                  <p className="text-sm text-stone-700 mt-2"><strong>Purpose:</strong> {data.framework.comm[comm].purpose}</p>
+                  <p className="text-sm text-stone-700 mt-2"><strong>Participants:</strong> {data.framework.comm[comm].participants}</p>
+                  <p className="text-sm text-stone-700 mt-2"><strong>Frequency:</strong> {data.framework.comm[comm].frequency}</p>
+                </div>
+              ) : <p className="text-stone-600">Click on an event above to see details.</p>}
+            </div>
+          </div>
+        </section>
+        <section id="practices" className={activeTab==='practices'?'mt-8':'hidden'}>
+          <div className="max-w-3xl mx-auto space-y-4">
+            {data.practices.map((p,i)=>(
+              <div key={i} className="bg-white rounded-lg border border-stone-200 shadow-sm">
+                <button className="accordion-toggle w-full text-left p-4 font-semibold" onClick={()=>toggleAcc('practice'+i)}>{p.title} {open['practice'+i]?'▲':'▼'}</button>
+                <div className={open['practice'+i]? 'p-4 pt-0 text-stone-600 text-sm' : 'hidden p-4 pt-0 text-stone-600 text-sm'}>{p.content}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+        {addons.map((Addon,i)=>(<Addon key={i}/>))}
+      </main>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  React.createElement(window.Blackboard.BlackboardProvider, null,
+    React.createElement(Scriptment, null)
+  )
+);

--- a/public/addons/HelloAddon.js
+++ b/public/addons/HelloAddon.js
@@ -1,0 +1,7 @@
+export default function HelloAddon(){
+  return React.createElement('div', {className:'p-4 bg-blue-50 rounded mt-4'}, 'Hello Addon Loaded');
+}
+
+if(window.Blackboard){
+  window.Blackboard.registerAddon(HelloAddon);
+}

--- a/public/addons/manifest.json
+++ b/public/addons/manifest.json
@@ -1,0 +1,3 @@
+{
+  "modules": ["HelloAddon.js"]
+}

--- a/public/blackboard.js
+++ b/public/blackboard.js
@@ -1,0 +1,24 @@
+const { createContext, useState, useEffect } = React;
+
+const AddonContext = createContext([]);
+const addonList = [];
+const listeners = new Set();
+
+function registerAddon(Addon) {
+  addonList.push(Addon);
+  listeners.forEach(l => l([...addonList]));
+}
+
+function BlackboardProvider({ children }) {
+  const [addons, setAddons] = useState(addonList);
+  useEffect(() => {
+    const listener = list => setAddons(list);
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }, []);
+  return React.createElement(AddonContext.Provider, { value: addons }, children);
+}
+
+window.Blackboard = { registerAddon, AddonContext, BlackboardProvider };
+
+export { registerAddon, AddonContext, BlackboardProvider };

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="module" src="blackboard.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -27,14 +28,16 @@
   </style>
 </head>
 <body class="bg-stone-50 text-stone-800">
+  <div class="p-4 text-right"><a href="scriptment.html" class="text-teal-600">Scriptment</a></div>
   <div id="root"></div>
   <script type="text/babel">
-const { useState, useEffect } = React;
-function App() {
+const { useState, useEffect, useContext } = React;
+function CosmicNexusApp() {
   const [activeTab, setActiveTab] = useState('team');
   const [flipped, setFlipped] = useState({});
   const [open, setOpen] = useState({});
   const [comm, setComm] = useState(null);
+  const addons = useContext(window.Blackboard.AddonContext || React.createContext([]));
 
   useEffect(() => {
     if (activeTab === 'sprint') {
@@ -269,10 +272,15 @@ function App() {
           </div>
         </section>
       </main>
+      {addons && addons.map((Addon,i)=><Addon key={i}/>)}
     </div>
   );
 }
-ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+ReactDOM.createRoot(document.getElementById('root')).render(
+  React.createElement(window.Blackboard.BlackboardProvider, null,
+    React.createElement(CosmicNexusApp, null)
+  )
+);
   </script>
 </body>
 </html>

--- a/public/scenes.json
+++ b/public/scenes.json
@@ -1,0 +1,146 @@
+{
+  "team": [
+    {
+      "name": "Daria",
+      "emoji": "\ud83d\udc51",
+      "role": "Product Owner",
+      "mission": "Core Mission: Maximize Product Value",
+      "responsibilities": [
+        "Defines Product Goal and Sprint Goals",
+        "Creates and prioritizes the Product Backlog",
+        "Represents stakeholder needs",
+        "Accepts or rejects work results",
+        "Has final say on product decisions"
+      ]
+    },
+    {
+      "name": "Codex",
+      "emoji": "\ud83d\udd27",
+      "role": "Developer",
+      "mission": "Core Mission: Deliver a \"Done\" Increment",
+      "responsibilities": [
+        "Turns backlog items into a 'Done' increment",
+        "Creates and manages the Sprint Backlog",
+        "Adheres to the Definition of Done",
+        "Adapts the plan daily",
+        "Self-organizes the implementation"
+      ]
+    },
+    {
+      "name": "Core-Cosmo",
+      "emoji": "\ud83d\udee1\ufe0f",
+      "role": "Scrum Master",
+      "mission": "Core Mission: Optimize Team Process",
+      "responsibilities": [
+        "Coaches the team in Scrum",
+        "Removes impediments",
+        "Facilitates Scrum events",
+        "Protects the team from distractions",
+        "Fosters continuous improvement"
+      ]
+    }
+  ],
+  "sprint": {
+    "title": "Sprint 1 Plan: User Authentication",
+    "goal": "Establish user registration and login",
+    "stories": [
+      {
+        "name": "Story 1: Create Account (5)",
+        "description": "As a new visitor, I want to create an account.",
+        "acceptance": [
+          "Successful registration redirects to login",
+          "Existing email shows an error"
+        ],
+        "tasks": [
+          "Create `users` table",
+          "Build registration UI",
+          "Implement `/register` API",
+          "Implement password hashing",
+          "Write unit tests"
+        ]
+      },
+      {
+        "name": "Story 2: User Login (3)",
+        "description": "As a registered user, I want to log in.",
+        "acceptance": [
+          "Login redirects to dashboard",
+          "Incorrect credentials show an error"
+        ],
+        "tasks": [
+          "Build login UI",
+          "Implement `/login` API",
+          "Implement password comparison",
+          "Create session token",
+          "Write unit tests"
+        ]
+      },
+      {
+        "name": "Story 3: User Logout (2)",
+        "description": "As a logged-in user, I want a logout button.",
+        "acceptance": [
+          "Logout ends session and redirects"
+        ],
+        "tasks": [
+          "Add logout button",
+          "Implement `/logout` API",
+          "Clear client session"
+        ]
+      }
+    ]
+  },
+  "framework": {
+    "ac": [
+      "Scope: A single User Story",
+      "Purpose: Confirms story requirements",
+      "Author: Product Owner with Developer",
+      "Example: 'Given incorrect password, show error.'"
+    ],
+    "dod": [
+      "Scope: All items",
+      "Purpose: Consistent quality",
+      "Author: Entire team",
+      "Example: 'Code peer-reviewed, tests >80%'"
+    ],
+    "comm": {
+      "Daily Scrum": {
+        "purpose": "A 15-minute daily planning event for the Developers to inspect progress toward the Sprint Goal and adapt the plan.",
+        "participants": "Required: Codex. Facilitator: Core-Cosmo. Observer: Daria.",
+        "frequency": "Daily at a consistent time."
+      },
+      "Sprint Planning": {
+        "purpose": "Define the Sprint Goal and select the work for the upcoming sprint.",
+        "participants": "Required: Daria, Codex, Core-Cosmo.",
+        "frequency": "At the beginning of every sprint."
+      },
+      "Backlog Refinement": {
+        "purpose": "Clarify and estimate upcoming Product Backlog items.",
+        "participants": "Required: Daria, Codex. Optional: Core-Cosmo.",
+        "frequency": "Ongoing, typically 1-2 hours per sprint."
+      },
+      "Sprint Review": {
+        "purpose": "Show the 'Done' increment to stakeholders to gather feedback.",
+        "participants": "Required: Daria, Codex, Core-Cosmo, stakeholders.",
+        "frequency": "At the end of every sprint."
+      },
+      "Retrospective": {
+        "purpose": "Reflect on the past sprint and plan improvements.",
+        "participants": "Required: Daria, Codex, Core-Cosmo (team only).",
+        "frequency": "At the end of every sprint, after the review."
+      }
+    }
+  },
+  "practices": [
+    {
+      "title": "The First Retrospective",
+      "content": "The first retrospective is crucial. Keep it simple and focus on actionable improvements."
+    },
+    {
+      "title": "Continuous Backlog Refinement",
+      "content": "Dedicate time each sprint to discuss upcoming work."
+    },
+    {
+      "title": "Avoiding Anti-Patterns",
+      "content": "Daily Scrum is not a status report. Never ignore the Definition of Done."
+    }
+  ]
+}

--- a/public/scriptment.html
+++ b/public/scriptment.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scriptment</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="module" src="blackboard.js"></script>
+</head>
+<body class="bg-stone-50 text-stone-800">
+  <div class="p-4"><a href="index.html" class="text-teal-600">&larr; Back</a></div>
+  <div id="root"></div>
+  <script type="text/babel" src="Scriptment.jsx"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `blackboard.js` with global addon registry
- update index view to use `CosmicNexusApp` and show registered addons
- load blackboard in `scriptment.html` and `index.html`
- refactor `Scriptment.jsx` to register addons via the blackboard
- document webporting addon usage in README
- provide `HelloAddon` example registering itself

## Testing
- `npx hardhat compile`
- `npm test`
- `npm run test:contracts`


------
https://chatgpt.com/codex/tasks/task_e_687af79d8d0c832ca5487bc55edc04d2