### PR TITLE
Add early exit for missing env vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !GEMINI_API_KEY) {
     console.error("CRITICAL ERROR: Missing environment variables.");
+    // Exit early when essential configuration is missing
+    process.exit(1);
 }
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- terminate server startup if critical environment variables are missing

## Testing
- `npx hardhat compile`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b03d6f590832c9346050d468844c4