### PR TITLE
Add compile step to test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The server requires several variables. Create a `.env` file or configure them in
    ```bash
    npm install
    ```
-2. Compile the Solidity contracts (required before running tests):
+2. Compile the Solidity contracts (required before deploying or interacting directly). The test script runs this step automatically:
    ```bash
    npx hardhat compile
    ```
@@ -47,7 +47,7 @@ Open `public/index.html` in your browser to view the React Agile blueprint.
 
 ## Tests
 
-Run API and contract tests:
+Run API and contract tests. The `npm test` command automatically compiles the contracts before executing Jest:
 
 ```bash
 npm test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "supertest": "^7.1.1"
   },
   "scripts": {
-    "test": "jest",
+    "test": "hardhat compile && jest",
     "test:contracts": "hardhat test"
   },
   "jest": {


### PR DESCRIPTION
## Summary
- run `hardhat compile` automatically when executing `npm test`
- note the auto compile step in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b03da10f4832c890dd67d86fda2c0