### PR TITLE
Add Scriptment view with plugin loader

### DIFF
--- a/public/Scriptment.jsx
+++ b/public/Scriptment.jsx
@@ -1,0 +1,50 @@
+const { useState, useEffect } = React;
+
+function Scriptment() {
+  const [script, setScript] = useState(null);
+  const [addons, setAddons] = useState({});
+
+  useEffect(() => {
+    fetch('./scriptment-content.json')
+      .then(r => r.json())
+      .then(setScript)
+      .catch(err => console.error('Script load error:', err));
+  }, []);
+
+  useEffect(() => {
+    if (!script) return;
+    const names = [...new Set(script.scenes.flatMap(s => s.addons || []))];
+    names.forEach(name => {
+      if (!addons[name]) {
+        import(`./addons/${name}.js`)
+          .then(mod => setAddons(prev => ({ ...prev, [name]: mod.default })))
+          .catch(err => console.error('Add-on load error:', err));
+      }
+    });
+  }, [script]);
+
+  if (!script) {
+    return React.createElement('div', { className: 'p-4' }, 'Loading script...');
+  }
+
+  return (
+    React.createElement('div', { className: 'p-4' },
+      React.createElement('h2', { className: 'text-2xl font-bold mb-4' }, script.title),
+      script.scenes.map(scene => (
+        React.createElement('div', { key: scene.id, className: 'mb-6' },
+          React.createElement('h3', { className: 'text-xl font-semibold mb-2' }, scene.title),
+          scene.lines.map((line, idx) => (
+            React.createElement('p', { key: idx, className: 'ml-4' },
+              React.createElement('strong', null, line.character + ': '),
+              line.text
+            )
+          )),
+          (scene.addons || []).map(name => {
+            const Addon = addons[name];
+            return Addon ? React.createElement(Addon, { key: name }) : null;
+          })
+        )
+      ))
+    )
+  );
+}

--- a/public/addons/sampleAddon.js
+++ b/public/addons/sampleAddon.js
@@ -1,0 +1,3 @@
+export default function SampleAddon() {
+  return React.createElement('div', { className: 'p-4 my-2 bg-yellow-50 border border-yellow-300 rounded' }, 'Sample Add-on Loaded');
+}

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
 </head>
 <body class="bg-stone-50 text-stone-800">
   <div id="root"></div>
+  <script type="text/babel" src="Scriptment.jsx"></script>
   <script type="text/babel">
 const { useState, useEffect } = React;
 function App() {
@@ -83,14 +84,15 @@ function App() {
 
       <nav className="mb-8 border-b border-stone-200">
         <ul className="flex flex-wrap -mb-px text-sm font-medium text-center text-stone-500">
-          {['team','sprint','framework','practices'].map(tab => (
+          {['team','scriptment','sprint','framework','practices'].map(tab => (
             <li key={tab} className="mr-2">
               <button className={`nav-tab inline-block p-4 border-b-2 rounded-t-lg ${activeTab===tab?'tab-active':'tab-inactive'}`} onClick={() => setActiveTab(tab)}>
                 {tab==='team' && <span className="hidden sm:inline">👥</span>}
+                {tab==='scriptment' && <span className="hidden sm:inline">📜</span>}
                 {tab==='sprint' && <span className="hidden sm:inline">🚀</span>}
                 {tab==='framework' && <span className="hidden sm:inline">🏗️</span>}
                 {tab==='practices' && <span className="hidden sm:inline">💡</span>}
-                {tab==='team' ? ' Team Overview' : tab==='sprint' ? ' Sprint 1 Plan' : tab==='framework' ? ' Agile Framework' : ' Best Practices'}
+                {tab==='team' ? ' Team Overview' : tab==='scriptment' ? ' Scriptment' : tab==='sprint' ? ' Sprint 1 Plan' : tab==='framework' ? ' Agile Framework' : ' Best Practices'}
               </button>
             </li>
           ))}
@@ -148,6 +150,10 @@ function App() {
               </div>
             ))}
           </div>
+        </section>
+
+        <section id="scriptment" className={activeTab==='scriptment'?'content-section active':'content-section'}>
+          <Scriptment />
         </section>
 
         <section id="sprint" className={activeTab==='sprint'?'content-section active':'content-section'}>

--- a/public/scriptment-content.json
+++ b/public/scriptment-content.json
@@ -1,0 +1,15 @@
+{
+  "title": "Demo Scriptment",
+  "scenes": [
+    {
+      "id": 1,
+      "title": "Opening",
+      "lines": [
+        {"character": "Narrator", "text": "Welcome to the Scriptment demo."},
+        {"character": "User", "text": "These lines come from JSON."},
+        {"character": "Codex", "text": "Plug-ins render below."}
+      ],
+      "addons": ["sampleAddon"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement `Scriptment.jsx` component to render script data and load addons
- store script in `scriptment-content.json`
- dynamic addon example in `addons/sampleAddon.js`
- expose new Scriptment tab and mount component in `index.html`

## Testing
- `npx hardhat compile`
- `npm test`
- `npm run test:contracts`


------
https://chatgpt.com/codex/tasks/task_e_687b03dd0ca8832c81cd28b8639f070f