### PR TITLE
Update install docs and start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ The server requires several variables. Create a `.env` file or configure them in
    ```bash
    npm install
    ```
-2. Compile the Solidity contracts (required before running tests):
+2. Copy the sample environment file:
+   ```bash
+   cp .env.example .env
+   ```
+3. Compile the Solidity contracts (required before running tests):
    ```bash
    npx hardhat compile
    ```
@@ -40,7 +44,7 @@ The server requires several variables. Create a `.env` file or configure them in
 Start the Express server on port `3001`:
 
 ```bash
-node index.js
+npm start
 ```
 
 Open `public/index.html` in your browser to view the React Agile blueprint.
@@ -53,3 +57,9 @@ Run API and contract tests:
 npm test
 npm run test:contracts
 ```
+
+## Continuous Integration
+
+The repository includes a GitHub Actions workflow located at
+`.github/workflows/npm-publish-github-packages.yml`. It runs on Node.js 18 and
+publishes the package to GitHub Packages on each push to the `main` branch.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "supertest": "^7.1.1"
   },
   "scripts": {
+    "start": "node index.js",
     "test": "jest",
     "test:contracts": "hardhat test"
   },


### PR DESCRIPTION
## Summary
- document copying `.env.example` and starting the server with `npm start`
- describe CI workflow
- add `npm start` script

## Testing
- `npx hardhat compile`
- `npm test`
- `npm run test:contracts`


------
https://chatgpt.com/codex/tasks/task_e_687b55ade594832cbf32c3618343db56