### PR TITLE
Use CommonJS in API modules

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,13 +1,13 @@
-import OpenAI from "openai";
+const OpenAI = require("openai");
 
 // Mini Xibalbá storage endpoint
-import { put, list, get } from '@vercel/blob';
+const { put, list, get } = require('@vercel/blob');
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const ASSISTANT_ID = process.env.ASSISTANT_ID;  // e.g. asst_xxx
 const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK_URL;
 
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   try {
     // 1. Handle Mini Xibalbá storage API
     if (req.url.endsWith('/api/xibalba-mini')) {
@@ -73,4 +73,4 @@ export default async function handler(req, res) {
     console.error('Cosmo Triage Error:', err);
     res.status(500).json({ error: 'Internal Server Error' });
   }
-}
+};

--- a/api/xibalba-mini.js
+++ b/api/xibalba-mini.js
@@ -1,7 +1,7 @@
-import { put, list, get } from '@vercel/blob';
+const { put, list, get } = require('@vercel/blob');
 
 // Endpoint: guarda/recupera mensajes JSON
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   const bucket = 'xibalba-mini';
   
   if (req.method === 'POST') {
@@ -18,4 +18,4 @@ export default async function handler(req, res) {
   }
 
   res.status(405).end();
-}
+};


### PR DESCRIPTION
## Summary
- switch chat API to CommonJS
- switch xibalba-mini API to CommonJS

## Testing
- `npx hardhat compile`
- `npm test`
- `npm run test:contracts`


------
https://chatgpt.com/codex/tasks/task_e_687b68b8d490832c95300c1d2ec17bed