### PR TITLE
Fix NFT static call mocking

### DIFF
--- a/api-tests/app.test.js
+++ b/api-tests/app.test.js
@@ -7,7 +7,7 @@ const { app, supabase, credit, nft } = require('../index');
 describe('API routes', () => {
   beforeAll(() => {
     jest.spyOn(credit, 'mint').mockImplementation(() => Promise.resolve({ wait: () => Promise.resolve(), hash: '0x123' }));
-    nft.callStatic = { mintWithURI: jest.fn().mockResolvedValue(1) };
+    nft.mintWithURI.staticCall = jest.fn().mockResolvedValue(1);
     jest.spyOn(nft, 'mintWithURI').mockImplementation(() => Promise.resolve({ wait: () => Promise.resolve(), hash: '0xabc' }));
     jest.spyOn(supabase, 'from').mockImplementation(() => ({
       insert: () => ({ select: () => ({ single: () => Promise.resolve({ data: { id: 1 }, error: null }) }) }),


### PR DESCRIPTION
## Summary
- mock `nft.mintWithURI.staticCall` in api tests

## Testing
- `npm run test:contracts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b68b9bb78832c86a345d8a0d766a6